### PR TITLE
Added Tebex checkout endpoint

### DIFF
--- a/lib/endpoints/checkout.js
+++ b/lib/endpoints/checkout.js
@@ -1,0 +1,33 @@
+import { ApiEndpoint } from './model';
+import { formatEndpoint, makeApiPromise } from '../utils';
+import { Endpoints } from '../const';
+
+export class Checkout extends ApiEndpoint {
+    /**
+     * Checkout object
+     *
+     * @typedef {object} CheckoutCart
+     * @property {string} url
+     * @property {Date} expires
+     */
+
+    /**
+     * Create a Tebex checkout URL
+     *
+     * @param {string} packageID
+     * @param {string} username
+     * @returns {Promise<CheckoutCart>} The created checkout
+     * @throws {Error}
+     * @example
+     * tebexInstance.checkout.create(123, "SomeUser")
+     */
+    create(packageID, username) {
+        return makeApiPromise(this.axiosInstance, {
+            url: formatEndpoint(Endpoints.CHECKOUT),
+            data: { package_id: packageID, username }
+        }, (data) => ({
+            url: data.url,
+            expires: new Date(data.expires)
+        }));
+    }
+}

--- a/lib/endpoints/index.js
+++ b/lib/endpoints/index.js
@@ -1,3 +1,4 @@
+export * from './checkout';
 export * from './packages';
 export * from './payments';
 export * from './players';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { Error } from './errors';
 import {
-    Server, Payments, Players, Packages
+    Server, Payments, Players, Packages, Checkout
 } from './endpoints';
 
 /**
@@ -61,5 +61,11 @@ export class TebexInstance {
          * @type {Packages}
          */
         this.packages = new Packages(this.axiosInstance);
+
+        /**
+         * @public
+         * @type {Checkout}
+         */
+        this.checkout = new Checkout(this.axiosInstance);
     }
 }

--- a/node.d.ts
+++ b/node.d.ts
@@ -138,6 +138,15 @@ declare module 'api-tebex' {
         sales(): Promise<Sales[]>;
     }
 
+    export interface CheckoutCart {
+        url: string;
+        expires: Date;
+    }
+    
+    class Checkout extends ApiEndpoint {
+        create(packageID: string, username: string): Promise<CheckoutCart>
+    }
+    
     interface TebexInstanceOptions {
         timeout?: number;
         pluginUrl?: string;
@@ -151,5 +160,6 @@ declare module 'api-tebex' {
         public payments: Payments;
         public players: Players;
         public packages: Packages;
+        public checkout: Checkout;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-tebex",
-  "version": "0.1.8",
-  "description": "",
+  "version": "0.2.0",
+  "description": "A node.js library for interacting with the Tebex API",
   "main": "node.js",
   "typings": "node.d.ts",
   "scripts": {


### PR DESCRIPTION
This adds `tebexClient.checkout.create()` to the list of endpoints and bumps the version to **0.2.0**