### PR TITLE
Add player packages endpoint

### DIFF
--- a/lib/const.js
+++ b/lib/const.js
@@ -52,5 +52,5 @@ export const Endpoints = {
     CREATE_BAN: '/bans',
     SALES: '/sales',
     PLAYER: (id) => `/user/${id}`,
-    PLAYER_PACKAGES: (id) => `/user/${id}/packages`
+    PLAYER_PACKAGES: (id) => `/player/${id}/packages`
 };

--- a/lib/const.js
+++ b/lib/const.js
@@ -51,5 +51,6 @@ export const Endpoints = {
     BANS: '/bans',
     CREATE_BAN: '/bans',
     SALES: '/sales',
-    PLAYER: (id) => `/user/${id}`
+    PLAYER: (id) => `/user/${id}`,
+    PLAYER_PACKAGES: (id) => `/user/${id}/packages`
 };

--- a/lib/endpoints/checkout.js
+++ b/lib/endpoints/checkout.js
@@ -1,5 +1,6 @@
-import { ApiEndpoint } from './model';
 import { formatEndpoint, makeApiPromise } from '../utils';
+
+import { ApiEndpoint } from './model';
 import { Endpoints } from '../const';
 
 export class Checkout extends ApiEndpoint {

--- a/lib/endpoints/coupons.js
+++ b/lib/endpoints/coupons.js
@@ -1,5 +1,6 @@
-import { ApiEndpoint } from './model';
 import { formatEndpoint, makeApiPromise } from '../utils';
+
+import { ApiEndpoint } from './model';
 import { Endpoints } from '../const';
 
 export class Coupons extends ApiEndpoint {

--- a/lib/endpoints/packages.js
+++ b/lib/endpoints/packages.js
@@ -1,7 +1,8 @@
 import { Endpoints, SimplePackage } from '../const';
-import { makeApiPromise, formatEndpoint } from '../utils';
-import { Error } from '../errors/handler';
+import { formatEndpoint, makeApiPromise } from '../utils';
+
 import { ApiEndpoint } from './model';
+import { Error } from '../errors/handler';
 
 /**
  * @classdesc Packages data API.

--- a/lib/endpoints/payments.js
+++ b/lib/endpoints/payments.js
@@ -1,9 +1,13 @@
 import {
-    Endpoints, Currency, TebexPlayer, SimplePackage
+    Currency,
+    Endpoints,
+    SimplePackage,
+    TebexPlayer
 } from '../const';
-import { makeApiPromise, formatEndpoint } from '../utils';
-import { Error } from '../errors/handler';
+import { formatEndpoint, makeApiPromise } from '../utils';
+
 import { ApiEndpoint } from './model';
+import { Error } from '../errors/handler';
 
 /**
  * @classdesc Payments data API.

--- a/lib/endpoints/players.js
+++ b/lib/endpoints/players.js
@@ -1,7 +1,8 @@
-import { Endpoints } from '../const';
-import { makeApiPromise, formatEndpoint } from '../utils';
-import { Error } from '../errors/handler';
+import { formatEndpoint, makeApiPromise } from '../utils';
+
 import { ApiEndpoint } from './model';
+import { Endpoints } from '../const';
+import { Error } from '../errors/handler';
 
 /**
  * @classdesc Players data API.
@@ -36,6 +37,16 @@ export class Players extends ApiEndpoint {
      */
 
     /**
+     * Player Purchase object
+     *
+     * @typedef {object} PlayerPurchase
+     * @property {string} txn_id
+     * @property {Date} date
+     * @property {number} quantity
+     * @property {SimplePackage} package
+     */
+
+    /**
      * Returns player lookup information (similar to player lookup in control panel).
      * Available on Ultimate and above plans
      *
@@ -66,5 +77,29 @@ export class Players extends ApiEndpoint {
             })),
             purchaseTotals: data.purchaseTotals
         }));
+    }
+
+    /**
+     * Returns a list of all active (non-expired) packages that a customer has purchased.
+     *
+     * @param {number} user - The UUID or username of a player.
+     * @returns {Promise<PlayerPurchase[]>} Advanced information about a player.
+     * @throws {Error}
+     * @example
+     * // Retrieve a list of all active packages for a customer
+     * tebexInstance.players.packages(5252)
+     */
+    packages(user) {
+        if (!user) throw new Error('INVALID_REQUEST', 'The user id is missing');
+
+        return makeApiPromise(this.axiosInstance, { url: formatEndpoint(Endpoints.PLAYER_PACKAGES, user) }, (data) => data.map((p) => ({
+            txn_id: data.txn_id,
+            date: new Date(data.date),
+            quantity: data.quantity,
+            package: {
+                id: data.package.id,
+                name: data.package.name
+            }
+        })));
     }
 }

--- a/lib/endpoints/players.js
+++ b/lib/endpoints/players.js
@@ -50,7 +50,7 @@ export class Players extends ApiEndpoint {
      * Returns player lookup information (similar to player lookup in control panel).
      * Available on Ultimate and above plans
      *
-     * @param {number} user - The UUID or username of a player.
+     * @param {number | string} user - The UUID or username of a player.
      * @returns {Promise<PlayerInfo>} Advanced information about a player.
      * @throws {Error}
      * @example
@@ -82,7 +82,7 @@ export class Players extends ApiEndpoint {
     /**
      * Returns a list of all active (non-expired) packages that a customer has purchased.
      *
-     * @param {number} user - The UUID or username of a player.
+     * @param {number | string} user - The UUID or username of a player.
      * @returns {Promise<PlayerPurchase[]>} Advanced information about a player.
      * @throws {Error}
      * @example
@@ -93,12 +93,12 @@ export class Players extends ApiEndpoint {
         if (!user) throw new Error('INVALID_REQUEST', 'The user id is missing');
 
         return makeApiPromise(this.axiosInstance, { url: formatEndpoint(Endpoints.PLAYER_PACKAGES, user) }, (data) => data.map((p) => ({
-            txn_id: data.txn_id,
-            date: new Date(data.date),
-            quantity: data.quantity,
+            txn_id: p.txn_id,
+            date: new Date(p.date),
+            quantity: p.quantity,
             package: {
-                id: data.package.id,
-                name: data.package.name
+                id: p.package.id,
+                name: p.package.name
             }
         })));
     }

--- a/lib/endpoints/server.js
+++ b/lib/endpoints/server.js
@@ -1,7 +1,8 @@
-import { Endpoints, Currency } from '../const';
-import { makeApiPromise, formatEndpoint } from '../utils';
-import { Error } from '../errors/handler';
+import { Currency, Endpoints } from '../const';
+import { formatEndpoint, makeApiPromise } from '../utils';
+
 import { ApiEndpoint } from './model';
+import { Error } from '../errors/handler';
 
 /**
  * @classdesc Server data API.

--- a/lib/errors/handler.js
+++ b/lib/errors/handler.js
@@ -42,6 +42,7 @@ const makeJsError = (Base) => class JsError extends Base {
 
 /**
  * Register an error code and message.
+ *
  * @param {string} sym Unique name for the error
  * @param {*} val Value of the error
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,6 @@ export class TebexInstance {
          * @public
          * @type {Coupons}
          */
-         this.coupons = new Coupons(this.axiosInstance);
+        this.coupons = new Coupons(this.axiosInstance);
     }
 }

--- a/node.d.ts
+++ b/node.d.ts
@@ -92,8 +92,19 @@ declare module 'api-tebex' {
         purchaseTotals: { [currency: string]: number };
     }
 
+    export type PlayerPackages = {
+        txn_id: string,
+        date: Date,
+        quantity: number,
+        package: {
+            id: number,
+            name: string
+        }
+    }[]
+
     class Players extends ApiEndpoint {
         retrieve(user: string): Promise<PlayerInfo>;
+        packages(user: string): Promise<>
     }
 
     export interface WebstoreInformation {

--- a/node.d.ts
+++ b/node.d.ts
@@ -104,7 +104,7 @@ declare module 'api-tebex' {
 
     class Players extends ApiEndpoint {
         retrieve(user: number | string): Promise<PlayerInfo>;
-        packages(user: number | string): Promise<>
+        packages(user: number | string): Promise<PlayerPackages[]>
     }
 
     export interface WebstoreInformation {

--- a/node.d.ts
+++ b/node.d.ts
@@ -103,8 +103,8 @@ declare module 'api-tebex' {
     }[]
 
     class Players extends ApiEndpoint {
-        retrieve(user: string): Promise<PlayerInfo>;
-        packages(user: string): Promise<>
+        retrieve(user: number | string): Promise<PlayerInfo>;
+        packages(user: number | string): Promise<>
     }
 
     export interface WebstoreInformation {

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,7 @@ const { TebexInstance } = require('../web-dev');
 const server = new TebexInstance(process.ENV.TEBEX_SECRET_KEY, { timeout: 5000 });
 const run = async () => {
     console.log(await server.players.retrieve(1805420));
+    console.log(await server.players.packages(1805420));
     console.log(await server.server.information());
     console.log(await server.packages.all());
     console.log(await server.payments.all(1));


### PR DESCRIPTION
This adds a wrapper around the [`/player/:id/packages`](https://docs.tebex.io/plugin/endpoints/customer-purchases) endpoint.

Allows you to fetch an array of active (non-expired) packages that a customer has purchased.