### PR TITLE
Add listing endpoint

### DIFF
--- a/lib/endpoints/packages.js
+++ b/lib/endpoints/packages.js
@@ -44,6 +44,39 @@ export class Packages extends ApiEndpoint {
      */
 
     /**
+     * Listing package object
+     *
+     * @typedef {object} ListingPackage
+     * @property {number} id The package ID.
+     * @property {number} order The order in which the package should be displayed.
+     * @property {string} name The package name.
+     * @property {string} price The price of the package (in the default webstore currency).
+     * @property {string} discounted_price The price of the package reduced by the discount value of its active sale.
+     * @property {string | false} image The package image URL.
+     * @property {object} sale
+     * @property {boolean} sale.active Whether the package is on sale.
+     * @property {string} sale.discount The discount to apply to the price of the package.
+     */
+
+    /**
+     * Listing category object
+     *
+     * @typedef {object} ListingCategory
+     * @property {number} id The category ID.
+     * @property {number} order The order in which the category should be displayed.
+     * @property {string} name The category name.
+     * @property {boolean} only_subcategories Whether the category should only display subcategories.
+     * @property {ListingPackage[]} packages The packages in the category.
+     */
+
+    /**
+     * Listing object
+     *
+     * @typedef {object} Listing
+     * @property {ListingCategory[]} categories
+     */
+
+    /**
      * Get a list of all packages on your webstore.
      *
      * @returns {Promise<Package[]>} Package information.
@@ -120,6 +153,30 @@ export class Packages extends ApiEndpoint {
             limitExpires: data.limit_expires,
             inheritCommands: data.inherit_commands,
             variableGiftcard: data.variable_giftcard
+        }));
+    }
+
+    /**
+     * Get the categories and packages which should be displayed to players in game.
+     *
+     * @returns {Promise<Listing>}
+     * @throws {Error}
+     * @example
+     * tebexInstance.packages.listing()
+     */
+    listing() {
+        return makeApiPromise(this.axiosInstance, { url: formatEndpoint(Endpoints.LISTING) }, (data) => ({
+            categories: data.categories.sort((a, b) => a.order - b.order).map((c) => ({
+                ...c,
+                packages: c.packages.sort((a, b) => a.order - b.order).map((p) => {
+                    const discountedPrice = p.sale.active ? Number(p.price) - Number(p.sale.discount) : Number(p.price);
+
+                    return {
+                        ...p,
+                        discounted_price: String(discountedPrice)
+                    };
+                })
+            }))
         }));
     }
 }

--- a/node.d.ts
+++ b/node.d.ts
@@ -38,9 +38,36 @@ declare module 'api-tebex' {
         variableGiftcard: number;
     }
 
+    export interface ListingPackage {
+        id: number;
+        order: number;
+        name: string;
+        price: string;
+        discounted_price: string;
+        image: string | false;
+        sale: {
+            active: boolean;
+            discount: number;
+        }
+    }
+
+    export interface ListingCategory {
+        id: number;
+        order: number;
+        name: string;
+        only_subcategories: boolean;
+        subcategories: any[];
+        packages: ListingPackage[];
+    }
+
+    export interface Listing {
+        categories: ListingCategory[]
+    }
+
     class Packages extends ApiEndpoint {
         all(): Promise<Package[]>;
         retrieve(id: string): Promise<Package>;
+        listing(): Promise<Listing>;
     }
 
     export interface Currency {


### PR DESCRIPTION
This adds a wrapper around the [`/listing`](https://docs.tebex.io/plugin/endpoints/listing) endpoint.

It gets the categories and packages which should be displayed to players in-game, with the appropriate ordering applied.